### PR TITLE
Merging developments done in Albacore fork

### DIFF
--- a/ElGamal.cabal
+++ b/ElGamal.cabal
@@ -1,22 +1,21 @@
--- This file has been generated from package.yaml by hpack version 0.21.2.
+-- This file has been generated from package.yaml by hpack version 0.28.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5df2e61fc94f8b0bec886b33189f91ccdae25ebcda4fffc02481071b5f477ccb
+-- hash: c1f25221d9a4f8245002b881199014e436262d926a836dfcce4951c354eae430
 
 name:           ElGamal
-version:        0.2.0.0
+version:        0.1.0.0
 description:    Please see the README on Github at <https://github.com/githubuser/ElGamal#readme>
 homepage:       https://github.com/githubuser/ElGamal#readme
 bug-reports:    https://github.com/githubuser/ElGamal/issues
 author:         Author name here
-maintainer:     ilyasridhuan@gmail.com
-copyright:      2018 Ilyas Ridhuan 
+maintainer:     example@example.com
+copyright:      2018 Author name here
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
 cabal-version:  >= 1.10
-
 extra-source-files:
     README.md
 

--- a/ElGamal.cabal
+++ b/ElGamal.cabal
@@ -1,63 +1,88 @@
-name:                ElGamal
-version:             0.1.0.0
--- synopsis:
--- description:
-homepage:            https://github.com/githubuser/ElGamal#readme
-license:             BSD3
-license-file:        LICENSE
-author:              Author name here
-maintainer:          example@example.com
-copyright:           2017 Author name here
-category:            Web
-build-type:          Simple
-extra-source-files:  README.md
-cabal-version:       >=1.10
+-- This file has been generated from package.yaml by hpack version 0.21.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 5df2e61fc94f8b0bec886b33189f91ccdae25ebcda4fffc02481071b5f477ccb
 
-library
-  hs-source-dirs:      src
-  exposed-modules:     ElGamal
-                    ,  ZKP
-                    ,  ElGamalComponents
-                    ,  ShamirSecretSharing
-                    ,  ThresholdElGamal
+name:           ElGamal
+version:        0.2.0.0
+description:    Please see the README on Github at <https://github.com/githubuser/ElGamal#readme>
+homepage:       https://github.com/githubuser/ElGamal#readme
+bug-reports:    https://github.com/githubuser/ElGamal/issues
+author:         Author name here
+maintainer:     ilyasridhuan@gmail.com
+copyright:      2018 Ilyas Ridhuan 
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+cabal-version:  >= 1.10
 
-  build-depends:       base >= 4.7 && < 5
-                    ,  cryptonite
-                    ,  transformers
-                    ,  split
-                    ,  MonadRandom
-                    ,  QuickCheck
-                    ,  bytestring
-  default-language:    Haskell2010
-
-executable ElGamal-exe
-  hs-source-dirs:      app
-  main-is:             Main.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  build-depends:       base
-                     , ElGamal
-  default-language:    Haskell2010
-
-test-suite ElGamal-test
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
-                    ,  src
-  other-modules:       ElGamalTest
-                    ,  ElGamalComponents
-                    ,  ElGamal
-                    ,  ZKP
-                    ,  ShamirSecretSharing
-                    ,  ThresholdElGamal
-                    ,  ZKPTest
-  main-is:             Spec.hs
-  build-depends:       base
-                     , QuickCheck
-                     , cryptonite
-                     , split
-                     , bytestring
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  default-language:    Haskell2010
+extra-source-files:
+    README.md
 
 source-repository head
-  type:     git
+  type: git
   location: https://github.com/githubuser/ElGamal
+
+library
+  exposed-modules:
+      ElGamal
+      ElGamalComponents
+      ZKP
+      ShamirSecretSharing
+      ThresholdElGamal
+  other-modules:
+      Paths_ElGamal
+  hs-source-dirs:
+      src
+  build-depends:
+      MonadRandom
+    , QuickCheck
+    , base >=4.7 && <5
+    , bytestring
+    , cryptonite
+    , integer-logarithms
+    , split
+    , transformers
+  default-language: Haskell2010
+
+executable ElGamal
+  main-is: Main.hs
+  other-modules:
+      Paths_ElGamal
+  hs-source-dirs:
+      app
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -fno-warn-orphans
+  build-depends:
+      ElGamal
+    , MonadRandom
+    , QuickCheck
+    , base >=4.7 && <5
+    , bytestring
+    , cryptonite
+    , integer-logarithms
+    , split
+    , transformers
+  default-language: Haskell2010
+
+test-suite ElGamal-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      ElGamalTest
+      ZKPTest
+      Paths_ElGamal
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -fno-warn-orphans
+  build-depends:
+      ElGamal
+    , MonadRandom
+    , QuickCheck
+    , base >=4.7 && <5
+    , bytestring
+    , cryptonite
+    , integer-logarithms
+    , split
+    , transformers
+  default-language: Haskell2010

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,9 +15,9 @@ main = do
     -- Calculate verification keys for the threshold keys
     let verKeys = genVerificationKeys pub threshKeys
     -- Encrypt the number 20 with standard ElGamal
-    ct@(CipherText (α,β)) <- standardEncrypt pub (PlainText 20)
+    ct <- standardEncrypt pub (PlainText 20)
     -- Calculate partial decryptions with all the threshold keys
-    let part = (\x -> partialDecrypt x pub ct) <$> threshKeys
+    let part = (\key -> partialDecrypt key pub ct) <$> threshKeys
     -- Calculate the non interactive zero knowledge proofs associated with each decryption
     arr <- traverse (uncurry3 (nonInteractiveEqofDL pub ct)) $ zip3 threshKeys verKeys part
     -- Verify that the NIZKP are true

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,72 @@
+name:                ElGamal
+version:             0.1.0.0
+github:              "githubuser/ElGamal"
+license:             BSD3
+author:              "Author name here"
+maintainer:          "example@example.com"
+copyright:           "2018 Author name here"
+
+extra-source-files:
+- README.md
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            Web
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description:         Please see the README on Github at <https://github.com/githubuser/ElGamal#readme>
+
+dependencies:
+- base >= 4.7 && < 5
+- cryptonite
+- bytestring
+- QuickCheck
+- split
+- MonadRandom
+- integer-logarithms
+- transformers
+
+library:
+  source-dirs:
+  - src
+
+  exposed-modules:
+  - ElGamal
+  - ElGamalComponents
+  - ZKP
+  - ShamirSecretSharing
+  - ThresholdElGamal
+
+executables:
+  ElGamal:
+    main:             Main.hs
+    source-dirs:         app
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    - -Wall
+    - -Werror
+    - -fno-warn-orphans
+
+    dependencies:
+    - ElGamal
+
+
+
+tests:
+  ElGamal-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    - -Wall
+    - -Werror
+    - -fno-warn-orphans
+
+    dependencies:
+    - ElGamal

--- a/src/ElGamal.hs
+++ b/src/ElGamal.hs
@@ -7,11 +7,10 @@ import Crypto.Random
 import Crypto.Number.Prime
 import Crypto.Number.ModArithmetic
 import Crypto.Number.Generate
-import Data.List.Split
 import ElGamalComponents
 
 
-genKeys :: Int -> IO (PublicKey,PrivateKey)
+genKeys :: MonadRandom m => Int -> m (PublicKey,PrivateKey)
 genKeys bits = do
     p <- generateSafePrime bits
     let q = (p - 1) `div` 2

--- a/src/ElGamal.hs
+++ b/src/ElGamal.hs
@@ -60,7 +60,7 @@ standardDecrypt PrivateKey{..} (CipherText (α,β,p)) = do
 
 newGenerator :: MonadRandom m => Integer -> Integer -> Integer -> m Integer
 newGenerator q p gCand
-    | expSafe gCand q p == 1 && gCand ^ 2 /= 1 = return gCand
+    | expSafe gCand q p == 1 && gCand ^ (2 :: Integer) /= (1 :: Integer) = return gCand
     | otherwise = generateBetween 1 (p-1) >>= newGenerator q p
 
 findGM :: PlainText -> PublicKey -> Integer -> PlainText

--- a/src/ElGamalComponents.hs
+++ b/src/ElGamalComponents.hs
@@ -3,7 +3,7 @@ module ElGamalComponents where
 
 import Crypto.Hash
 import Data.Char
-import Data.Semigroup
+import Data.Semigroup()
 
 data PublicKey = PublicKey {
     q :: Integer,
@@ -17,7 +17,7 @@ newtype PlainText = PlainText Integer deriving (Show,Num,Enum,Integral,Real,Ord,
 newtype CipherText = CipherText (Integer,Integer,Integer) deriving (Show,Ord,Eq)
 
 instance Semigroup CipherText where
-    CipherText (a,b,n) <> CipherText(a',b',_) = CipherText ((a * a' `mod` n),(b * b' `mod` n),n)
+    CipherText (α,β,n) <> CipherText(α',β',_) = CipherText ((α * α' `mod` n),(β * β' `mod` n),n)
 
 
 type SplitKey = (Integer,PrivateKey)
@@ -40,20 +40,20 @@ data NIZKPDL = NIZKPDL {
 ------------- HELPER FUNCTIONS -------------------------
 
 uncurry3 :: (a -> b -> c -> d) -> ((a,b,c) -> d)
-uncurry3 f (x,y,z)  = f x y z
+uncurry3 f (x1,x2,x3)  = f x1 x2 x3
 
 uncurry4 :: (a -> b -> c -> d -> e) -> ((a,b,c,d) -> e)
-uncurry4 f (w,x,y,z)  = f w x y z
+uncurry4 f (w1,w2,w3,w4)  = f w1 w2 w3 w4
 
 checkCongruence:: Integer -> Integer -> Integer -> Bool
-checkCongruence a b modm
-    | (a-b) `mod` modm == 0 = True
+checkCongruence a_1 b_1 modm
+    | (a_1-b_1) `mod` modm == 0 = True
     | otherwise = False
 
 parseHex :: String -> Integer
 parseHex str = toInteger $ parser $ reverse str
     where
         parser []     = 0
-        parser (x:xs) = digitToInt x + 16 * parser xs
+        parser (h:hs) = digitToInt h + 16 * parser hs
 
 

--- a/src/ElGamalComponents.hs
+++ b/src/ElGamalComponents.hs
@@ -3,6 +3,7 @@ module ElGamalComponents where
 
 import Crypto.Hash
 import Data.Char
+import Data.Semigroup
 
 data PublicKey = PublicKey {
     q :: Integer,
@@ -13,17 +14,11 @@ data PublicKey = PublicKey {
 
 newtype PrivateKey = PrivateKey {x :: Integer} deriving (Show)
 newtype PlainText = PlainText Integer deriving (Show,Num,Enum,Integral,Real,Ord,Eq)
-newtype CipherText = CipherText (Integer,Integer) deriving (Show,Ord,Eq,Num)
+newtype CipherText = CipherText (Integer,Integer,Integer) deriving (Show,Ord,Eq)
 
+instance Semigroup CipherText where
+    CipherText (a,b,n) <> CipherText(a',b',_) = CipherText ((a * a' `mod` n),(b * b' `mod` n),n)
 
-instance (Num a, Num b) => Num (a,b) where
-        fromInteger x = (fromInteger x, fromInteger x)
-        (a,b) + (a',b') = (a + a', b + b')
-        (a,b) - (a',b') = (a - a', b - b')
-        (a,b) * (a',b') = (a * a', b * b')
-        negate (a,b) = (negate a, negate b)
-        abs (a,b) = (abs a, abs b)
-        signum (a,b) = (signum a, signum b)
 
 type SplitKey = (Integer,PrivateKey)
 type Coefficients = [Double]
@@ -41,7 +36,6 @@ data NIZKPDL = NIZKPDL {
     z :: Integer,
     fsHash :: Hash
 }
-
 
 ------------- HELPER FUNCTIONS -------------------------
 
@@ -61,3 +55,5 @@ parseHex str = toInteger $ parser $ reverse str
     where
         parser []     = 0
         parser (x:xs) = digitToInt x + 16 * parser xs
+
+

--- a/src/ShamirSecretSharing.hs
+++ b/src/ShamirSecretSharing.hs
@@ -6,14 +6,14 @@ module ShamirSecretSharing where
 import Crypto.Number.Generate
 import Crypto.Number.ModArithmetic
 import Data.List.Split
-import ElGamalComponents (SplitKey,Coefficients,PublicKey(..),PrivateKey(..))
+import ElGamalComponents (SplitKey,PublicKey(..),PrivateKey(..))
 import Data.Ratio
 
 genThresholdKeys :: PublicKey -> PrivateKey -> Integer -> Integer -> IO [SplitKey]
 genThresholdKeys PublicKey{..} PrivateKey{..} t m = do
     polyArray <- traverse (const $ generateBetween 0 x) [1..(t-1)]
     let polynomial = zip [1..] polyArray
-    let polyConstituents = (\x y -> expSafe x (fst y) p * snd y ) <$> [1..m] <*> polynomial
+    let polyConstituents = (\base key_shard -> expSafe base (fst key_shard) p * snd key_shard ) <$> [1..m] <*> polynomial
     let chunked = chunksOf (fromInteger t-1) polyConstituents
     return $ zip [1..] $ PrivateKey . foldr (+) x <$> chunked
 

--- a/src/ThresholdElGamal.hs
+++ b/src/ThresholdElGamal.hs
@@ -49,10 +49,10 @@ computeList pk@PublicKey{..} =
     traverse (\x -> fmap (flip (`expSafe` 1) q . (num x *)) (inverse (denom x) q))
 
 partialDecrypt :: SplitKey -> PublicKey -> CipherText -> (Integer,Integer)
-partialDecrypt (i,PrivateKey{..}) PublicKey {..} (CipherText (α,β)) = (i,expSafe α x p)
+partialDecrypt (i,PrivateKey{..}) PublicKey {..} (CipherText(α,β,n)) = (i,expSafe α x p)
 
 thresholdDecrypt :: PublicKey -> CipherText -> [(Integer,Integer)] -> Maybe PlainText
-thresholdDecrypt pk@PublicKey{..} (CipherText (α,β)) partialDec = do
+thresholdDecrypt pk@PublicKey{..} (CipherText(α,β,n)) partialDec = do
     coeffs <- coeffList pk $ fst <$> partialDec
     let lgProduct = product $ (\x -> uncurry expSafe x p) <$> zip (snd <$> partialDec) coeffs
     inv <- inverse lgProduct p

--- a/src/ThresholdElGamal.hs
+++ b/src/ThresholdElGamal.hs
@@ -2,13 +2,9 @@
 {-# LANGUAGE NamedFieldPuns             #-}
 module ThresholdElGamal where
 
-import ElGamal
-import ShamirSecretSharing
 import ElGamalComponents
 import Crypto.Number.ModArithmetic
 import Crypto.Number.Prime
-import Control.Applicative
-import Data.Maybe
 
 data LagrangePolynomial = LP {
     num :: Integer,
@@ -45,14 +41,14 @@ mkCoprimeList (l@LP{..}:lp)
         gcdDenom = denom `div` gCD
 
 computeList :: PublicKey -> [LagrangePolynomial] -> Maybe [Integer]
-computeList pk@PublicKey{..} =
+computeList PublicKey{..} =
     traverse (\x -> fmap (flip (`expSafe` 1) q . (num x *)) (inverse (denom x) q))
 
 partialDecrypt :: SplitKey -> PublicKey -> CipherText -> (Integer,Integer)
-partialDecrypt (i,PrivateKey{..}) PublicKey {..} (CipherText(α,β,n)) = (i,expSafe α x p)
+partialDecrypt (i,PrivateKey{..}) PublicKey {..} (CipherText(α,_,_)) = (i,expSafe α x p)
 
 thresholdDecrypt :: PublicKey -> CipherText -> [(Integer,Integer)] -> Maybe PlainText
-thresholdDecrypt pk@PublicKey{..} (CipherText(α,β,n)) partialDec = do
+thresholdDecrypt pk@PublicKey{..} (CipherText(_,β,_)) partialDec = do
     coeffs <- coeffList pk $ fst <$> partialDec
     let lgProduct = product $ (\x -> uncurry expSafe x p) <$> zip (snd <$> partialDec) coeffs
     inv <- inverse lgProduct p

--- a/src/ZKP.hs
+++ b/src/ZKP.hs
@@ -12,7 +12,7 @@ import ElGamal
 
 -- Sets up the initial commit if a^τ & b^τ by the prover of some random τ
 initialCommit :: MonadRandom m => PublicKey -> CipherText -> m (Integer,Integer,Integer)
-initialCommit PublicKey{..} (CipherText (α,_)) = do
+initialCommit PublicKey{..} (CipherText(α,β,n)) = do
     τ <- generateMax q
     return (expSafe g τ p, expSafe α τ p,τ)
 
@@ -36,7 +36,7 @@ verifierResponse PublicKey{..} γ1 γ2 v z u =
 
 -- Interactive equality of discrete logs for interactive ZKP
 checkEqualityOfDL :: PublicKey -> CipherText -> SplitKey -> (Integer,Integer) -> (Integer, Integer) -> IO Bool
-checkEqualityOfDL pub@PublicKey{..} ct@(CipherText (α,_)) (_,prv) vk pd  = do
+checkEqualityOfDL pub@PublicKey{..} ct@(CipherText(α,β,n)) (_,prv) vk pd  = do
     (a,b,τ) <- initialCommit pub ct
     u <- verifierChallenge pub
     let z = challengeResponse prv pub τ u
@@ -47,7 +47,7 @@ checkEqualityOfDL pub@PublicKey{..} ct@(CipherText (α,_)) (_,prv) vk pd  = do
 
 -- Non interactive equality of discrete logs using the fiat shamir heuristic
 nonInteractiveEqofDL :: PublicKey -> CipherText -> SplitKey -> (Integer,Integer) -> (Integer, Integer) -> IO NIZKPDL
-nonInteractiveEqofDL pub@PublicKey{..} ct@(CipherText (α,_)) (_,prv) vk pd  = do
+nonInteractiveEqofDL pub@PublicKey{..} ct@(CipherText(α,β,n)) (_,prv) vk pd  = do
     (a,b,τ) <- initialCommit pub ct
     let hsh = hash $ B8.pack $ show g ++ show (snd vk) ++ show α ++ show (snd pd) ++ show a ++ show b :: Hash
     let e = parseHex (show hsh )`mod` q
@@ -56,7 +56,7 @@ nonInteractiveEqofDL pub@PublicKey{..} ct@(CipherText (α,_)) (_,prv) vk pd  = d
 
 -- Verifying the ZKP of discrete logs by check the congruence between gz_1 === ay_1 (mod p) && gz_2 === ay_2 (mod p)
 verifyZKPofDL :: PublicKey -> CipherText -> NIZKPDL -> (Integer,Integer) -> (Integer, Integer) -> Bool
-verifyZKPofDL pub@PublicKey{..} (CipherText (α,_)) NIZKPDL{..} vk pd = checkCongruence gz ay p && checkCongruence αz bz p
+verifyZKPofDL pub@PublicKey{..} (CipherText(α,β,n)) NIZKPDL{..} vk pd = checkCongruence gz ay p && checkCongruence αz bz p
     where
         e = parseHex (show fsHash )`mod` q
         (ay,bz) = verifierResponse pub a b (snd vk) (snd pd) e

--- a/src/ZKP.hs
+++ b/src/ZKP.hs
@@ -7,19 +7,18 @@ import Crypto.Number.Generate
 import Crypto.Random.Types
 import Crypto.Hash
 import qualified Data.ByteString.Char8 as B8
-import ElGamal
 
 
 -- Sets up the initial commit if a^τ & b^τ by the prover of some random τ
 initialCommit :: MonadRandom m => PublicKey -> CipherText -> m (Integer,Integer,Integer)
-initialCommit PublicKey{..} (CipherText(α,β,n)) = do
+initialCommit PublicKey{..} (CipherText(α,_,_)) = do
     τ <- generateMax q
     return (expSafe g τ p, expSafe α τ p,τ)
 
 -- For interactive ZKP only. Generates some random integer e < 2^t where 2^t < q
 verifierChallenge :: MonadRandom m => PublicKey -> m Integer
 verifierChallenge PublicKey{..} = do
-    let maxi = floor $ logBase 2 (fromInteger q)
+    let maxi = floor (logBase 2 (fromInteger q) :: Double) :: Integer
     generateMax (2 ^ maxi)
 
 challengeResponse :: PrivateKey -> PublicKey -> Integer -> Integer -> Integer
@@ -36,7 +35,7 @@ verifierResponse PublicKey{..} γ1 γ2 v z u =
 
 -- Interactive equality of discrete logs for interactive ZKP
 checkEqualityOfDL :: PublicKey -> CipherText -> SplitKey -> (Integer,Integer) -> (Integer, Integer) -> IO Bool
-checkEqualityOfDL pub@PublicKey{..} ct@(CipherText(α,β,n)) (_,prv) vk pd  = do
+checkEqualityOfDL pub@PublicKey{..} ct@(CipherText(α,_,_)) (_,prv) vk pd  = do
     (a,b,τ) <- initialCommit pub ct
     u <- verifierChallenge pub
     let z = challengeResponse prv pub τ u
@@ -47,7 +46,7 @@ checkEqualityOfDL pub@PublicKey{..} ct@(CipherText(α,β,n)) (_,prv) vk pd  = do
 
 -- Non interactive equality of discrete logs using the fiat shamir heuristic
 nonInteractiveEqofDL :: PublicKey -> CipherText -> SplitKey -> (Integer,Integer) -> (Integer, Integer) -> IO NIZKPDL
-nonInteractiveEqofDL pub@PublicKey{..} ct@(CipherText(α,β,n)) (_,prv) vk pd  = do
+nonInteractiveEqofDL pub@PublicKey{..} ct@(CipherText(α,_,_)) (_,prv) vk pd  = do
     (a,b,τ) <- initialCommit pub ct
     let hsh = hash $ B8.pack $ show g ++ show (snd vk) ++ show α ++ show (snd pd) ++ show a ++ show b :: Hash
     let e = parseHex (show hsh )`mod` q
@@ -56,7 +55,7 @@ nonInteractiveEqofDL pub@PublicKey{..} ct@(CipherText(α,β,n)) (_,prv) vk pd  =
 
 -- Verifying the ZKP of discrete logs by check the congruence between gz_1 === ay_1 (mod p) && gz_2 === ay_2 (mod p)
 verifyZKPofDL :: PublicKey -> CipherText -> NIZKPDL -> (Integer,Integer) -> (Integer, Integer) -> Bool
-verifyZKPofDL pub@PublicKey{..} (CipherText(α,β,n)) NIZKPDL{..} vk pd = checkCongruence gz ay p && checkCongruence αz bz p
+verifyZKPofDL pub@PublicKey{..} (CipherText(α,_,_)) NIZKPDL{..} vk pd = checkCongruence gz ay p && checkCongruence αz bz p
     where
         e = parseHex (show fsHash )`mod` q
         (ay,bz) = verifierResponse pub a b (snd vk) (snd pd) e
@@ -65,12 +64,12 @@ verifyZKPofDL pub@PublicKey{..} (CipherText(α,β,n)) NIZKPDL{..} vk pd = checkC
 
 -- Basic Sigma Protocol for proving knowledge of the discrete logarithm of some y = g^x
 sigmaProtocol :: PrivateKey -> PublicKey -> IO Bool
-sigmaProtocol PrivateKey{..} pub@PublicKey{..} = do
+sigmaProtocol PrivateKey{..} PublicKey{..} = do
     let h = expFast g x p
     r <- generateMax q
     let a = expFast g r p
-    let t = floor $ logBase 2 (fromInteger q)
-    e <- generateMax (2 ^ t)
+    let t = floor (logBase 2 (fromInteger q) :: Double) :: Integer
+    e <- generateMax ( 2^t )
     let z = r + expFast (e * x) 1 q
     let gz = expFast g z p
     let he = expFast h e p
@@ -79,7 +78,7 @@ sigmaProtocol PrivateKey{..} pub@PublicKey{..} = do
 
 -- NonInteractive Sigma Protocol using the fiat Shamir heuristic
 nonInteractiveZKP :: PrivateKey -> PublicKey -> IO NIZKP
-nonInteractiveZKP PrivateKey{..} pub@PublicKey{..} = do
+nonInteractiveZKP PrivateKey{..} PublicKey{..} = do
     r <- generateMax q
     let a = expFast g r p
     let hsh = hash $ B8.pack $ show g ++ show y ++ show a :: Hash

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-10.0
+resolver: lts-12.12
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/ElGamalTest.hs
+++ b/test/ElGamalTest.hs
@@ -21,7 +21,7 @@ instance Arbitrary ValidBits where
 prop_EncryptDecrypt :: ValidBits -> PlainText -> Property
 prop_EncryptDecrypt bits pt@(PlainText plain) = monadicIO $ do
     (pub,prv) <- run $ genKeys (unValidBits bits)
-    Just (PlainText decryptedP) <- run $ standardDecrypt prv pub <$> standardEncrypt pub pt
+    Just (PlainText decryptedP) <- run $ standardDecrypt prv <$> standardEncrypt pub pt
     assert $ plain == decryptedP
 
 prop_MultiplicativeHomomorphism :: ValidBits -> PlainText -> PlainText -> Property
@@ -29,8 +29,8 @@ prop_MultiplicativeHomomorphism bits pt1@(PlainText plain1) pt2@(PlainText plain
     (pub,prv) <- run $ genKeys (unValidBits bits)
     ct <- run $ standardEncrypt pub pt1
     ct' <- run $ standardEncrypt pub pt2
-    let rt = ct * ct'
-    Just (PlainText decryptedMultiple) <- return $ standardDecrypt prv pub rt
+    let rt = ct <> ct'
+    Just (PlainText decryptedMultiple) <- return $ standardDecrypt prv rt
     assert $ decryptedMultiple == (plain1*plain2)
 
 prop_AdditiveHomomorphism :: ValidBits -> PlainText -> PlainText -> Property
@@ -38,6 +38,6 @@ prop_AdditiveHomomorphism bits pt1@(PlainText plain1) pt2@(PlainText plain2) = m
     (pub,prv) <- run $ genKeys (unValidBits bits)
     ct <- run $ modifiedEncrypt pub pt1
     ct' <- run $ modifiedEncrypt pub pt2
-    let rt = ct * ct'
+    let rt = ct <> ct'
     Just (PlainText decryptedAddition) <- return $ modifiedDecrypt prv pub rt
     assert $ decryptedAddition == (plain1 + plain2)

--- a/test/ElGamalTest.hs
+++ b/test/ElGamalTest.hs
@@ -1,51 +1,43 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module ElGamalTest where
 
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
-import Data.Maybe
 import ElGamal
-import Control.Monad.IO.Class
 import ElGamalComponents
+import Data.Bits
 
--- monadic fromJust $
+newtype ValidBits = ValidBits {unValidBits :: Int} deriving Show
+
 instance Arbitrary PlainText where
     arbitrary = do
         pt <- (arbitrary :: Gen Integer) `suchThat` (> 0)
         return $ PlainText pt
 
-newpropEncryptDecrypt :: PlainText -> Property
-newpropEncryptDecrypt pt@(PlainText plain) =  monadicIO $ do
-    bits <- run $ generate $ abs <$> (arbitrary :: Gen Int) `suchThat` (> 10)
-    -- run $ print bits
-    (pub,prv) <- run $ genKeys bits
-    Just (PlainText p) <- run $ standardDecrypt prv pub <$> standardEncrypt pub pt
-    assert $ plain == p
+instance Arbitrary ValidBits where
+    arbitrary = (arbitrary :: Gen Int) `suchThat` (\x_ -> ((>0) x_) && ((<58) . countLeadingZeros) x_) >>= return . ValidBits
 
-prop_EncryptDecrypt :: PublicKey -> PrivateKey -> PlainText -> Property
-prop_EncryptDecrypt pub prv pt@(PlainText plain) = monadicIO $ do
-    -- let ct = CipherText (10,10)
-    Just (PlainText p) <- run $ standardDecrypt prv pub <$> standardEncrypt pub pt
-    assert $ plain == p
+prop_EncryptDecrypt :: ValidBits -> PlainText -> Property
+prop_EncryptDecrypt bits pt@(PlainText plain) = monadicIO $ do
+    (pub,prv) <- run $ genKeys (unValidBits bits)
+    Just (PlainText decryptedP) <- run $ standardDecrypt prv pub <$> standardEncrypt pub pt
+    assert $ plain == decryptedP
 
-prop_MultiplicativeHomomorphism :: PlainText -> PlainText -> Property
-prop_MultiplicativeHomomorphism pt1@(PlainText plain1) pt2@(PlainText plain2) = monadicIO $ do
-    bits <- run $ generate $ abs <$> (arbitrary :: Gen Int) `suchThat` (> 32)
-    -- run $ print bits
-    (pub,prv) <- run $ genKeys bits
+prop_MultiplicativeHomomorphism :: ValidBits -> PlainText -> PlainText -> Property
+prop_MultiplicativeHomomorphism bits pt1@(PlainText plain1) pt2@(PlainText plain2) = monadicIO $ do
+    (pub,prv) <- run $ genKeys (unValidBits bits)
     ct <- run $ standardEncrypt pub pt1
     ct' <- run $ standardEncrypt pub pt2
-
     let rt = ct * ct'
-    Just (PlainText p) <- return $ standardDecrypt prv pub rt
-    assert $ p == (plain1*plain2)
+    Just (PlainText decryptedMultiple) <- return $ standardDecrypt prv pub rt
+    assert $ decryptedMultiple == (plain1*plain2)
 
-prop_AdditiveHomomorphism :: PlainText -> PlainText -> Property
-prop_AdditiveHomomorphism pt1@(PlainText plain1) pt2@(PlainText plain2) = monadicIO $ do
-    bits <- run $ generate $ abs <$> (arbitrary :: Gen Int) `suchThat` (> 32)
-    (pub,prv) <- run $ genKeys bits
+prop_AdditiveHomomorphism :: ValidBits -> PlainText -> PlainText -> Property
+prop_AdditiveHomomorphism bits pt1@(PlainText plain1) pt2@(PlainText plain2) = monadicIO $ do
+    (pub,prv) <- run $ genKeys (unValidBits bits)
     ct <- run $ modifiedEncrypt pub pt1
     ct' <- run $ modifiedEncrypt pub pt2
-
     let rt = ct * ct'
-    Just (PlainText p) <- return $ modifiedDecrypt prv pub rt
-    assert $ p == (plain1 + plain2)
+    Just (PlainText decryptedAddition) <- return $ modifiedDecrypt prv pub rt
+    assert $ decryptedAddition == (plain1 + plain2)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,12 +3,11 @@ module Main where
 import ElGamalTest
 import ZKPTest
 import Test.QuickCheck
-import Test.QuickCheck.Monadic
 
 main :: IO ()
 main = do
     quickCheckWith stdArgs { maxSuccess = 1000 } prop_MultiplicativeHomomorphism
-    quickCheckWith stdArgs { maxSuccess = 1000 } newpropEncryptDecrypt
+    quickCheckWith stdArgs { maxSuccess = 1000 } prop_EncryptDecrypt
     quickCheckWith stdArgs { maxSuccess = 1000 } prop_AdditiveHomomorphism
     quickCheckWith stdArgs { maxSuccess = 100 } prop_SingleNonInteractiveZKP
     quickCheckWith stdArgs { maxSuccess = 100 } prop_EqualityOfDL

--- a/test/ZKPTest.hs
+++ b/test/ZKPTest.hs
@@ -4,11 +4,9 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
 import ZKP
 import ShamirSecretSharing
-import ThresholdElGamal hiding (run)
+import ThresholdElGamal
 import ElGamalComponents
 import ElGamal
-import Crypto.Number.Generate
-import Crypto.Number.ModArithmetic
 
 prop_SingleNonInteractiveZKP :: Property
 prop_SingleNonInteractiveZKP = monadicIO $ do
@@ -25,8 +23,8 @@ prop_EqualityOfDL pt = monadicIO $ do
     lb <- run $ generate ( choose (3,ub) :: Gen Integer)
     threshKeys <- run $ genThresholdKeys pub prv lb ub
     let verKeys = genVerificationKeys pub threshKeys
-    ct@(CipherText (α,β)) <- run $ standardEncrypt pub pt
-    let part = (\x -> partialDecrypt x pub ct) <$> threshKeys
+    ct <- run $ standardEncrypt pub pt
+    let part = (\key -> partialDecrypt key pub ct) <$> threshKeys
     arr <- run $ traverse (uncurry3 (nonInteractiveEqofDL pub ct)) $ zip3 threshKeys verKeys part
     let boolArr = uncurry3 (verifyZKPofDL pub ct) <$> zip3 arr verKeys part
     assert $ condenseTruths boolArr


### PR DESCRIPTION
### Merging changes done in Albacore fork

- Bumped GHC version to LTS. 12-12 (8.4.3)
- Changed cipher text from being a instance of Num to semi group as only an associative binary operator (multiplication) was required, implementing the other Num operations was probably overkill and unnecessary
- Added the modulus (p) inside cipher text to make it easier for multiplication to occur without having to drag around the public key
- Quickchecks improved to ensure key generation were properly being tested (>6 bits, since safest prime has a minimum size)

- General cleanup of files and warnings